### PR TITLE
Enhance GitHub Actions workflow by explicitly enabling GitHub Pages in setup and deployment steps

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,8 @@ jobs:
 
       - name: Setup Pages
         uses: actions/configure-pages@v4
+        with:
+          enablement: true  # Explicitly enable GitHub Pages
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
@@ -31,3 +33,6 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          enablement: true  # Explicitly enable GitHub Pages


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration in `.github/workflows/deploy.yml` to explicitly enable GitHub Pages and ensure proper deployment.

Enhancements to GitHub Pages deployment:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R25-R26): Added `enablement: true` to the `actions/configure-pages@v4` step to explicitly enable GitHub Pages.
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R36-R38): Added `token` and `enablement: true` to the `actions/deploy-pages@v4` step to ensure secure and explicit deployment of GitHub Pages.